### PR TITLE
Refact : 채널 도메인영역 컨트롤러와 서비스 계층 로직 분리

### DIFF
--- a/backend/api/src/main/java/com/levelup/api/api/ChannelApiController.java
+++ b/backend/api/src/main/java/com/levelup/api/api/ChannelApiController.java
@@ -28,7 +28,6 @@ import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
-import javax.swing.filechooser.FileSystemView;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -57,18 +56,7 @@ public class ChannelApiController {
      * */
     @PostMapping("/channel")
     public CreateChannelResponse create(@RequestBody @Validated ChannelRequest channelRequest) {
-        Long channelId = channelService.create(channelRequest.getMemberEmail(), channelRequest.getName(),
-                channelRequest.getLimitedMemberNumber(), channelRequest.getDescription(),
-                channelRequest.getThumbnailDescription(), channelRequest.getCategory(),
-                channelRequest.getThumbnailImage());
-
-//        System.out.println(channelRequest.getThumbnailImage());
-//        System.out.println(channelRequest.getThumbnailImage().getStoreFileName());
-//        System.out.println(channelRequest.getThumbnailImage().getUploadFileName());
-        Channel findChannel = channelService.findOne(channelId);
-
-        return new CreateChannelResponse(findChannel.getName(), findChannel.getLimitedMemberNumber(),
-                findChannel.getManagerName(), findChannel.getDescription());
+        return channelService.create(channelRequest);
     }
 
     @PostMapping("/channel/descriptionFiles/base64")
@@ -235,7 +223,6 @@ public class ChannelApiController {
     }
 
 
-
     /**
      * 수정
      * */
@@ -251,7 +238,6 @@ public class ChannelApiController {
                 findChannel.getThumbnailDescription(), findChannel.getThumbnailImage()),
                 HttpStatus.OK);
     }
-
 
 
     /**

--- a/backend/api/src/main/java/com/levelup/api/api/ChannelApiController.java
+++ b/backend/api/src/main/java/com/levelup/api/api/ChannelApiController.java
@@ -1,26 +1,20 @@
 package com.levelup.api.api;
 
 import com.levelup.api.service.ChannelService;
-import com.levelup.api.service.FileService;
 import com.levelup.api.service.MemberService;
 import com.levelup.core.domain.channel.Channel;
 import com.levelup.core.domain.channel.ChannelCategory;
 import com.levelup.core.domain.file.Base64Dto;
-import com.levelup.core.domain.file.FileStore;
-import com.levelup.core.domain.file.ImageType;
 import com.levelup.core.domain.file.UploadFile;
-import com.levelup.core.domain.member.Member;
 import com.levelup.core.dto.Result;
 import com.levelup.core.dto.channel.*;
 import com.levelup.core.dto.member.MemberResponse;
-import com.levelup.core.exception.ImageNotFoundException;
+import com.levelup.core.repository.channel.ChannelRepository;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.io.Resource;
-import org.springframework.core.io.UrlResource;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -28,14 +22,10 @@ import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.time.format.DateTimeFormatter;
-import java.util.Base64;
 import java.util.List;
-import java.util.stream.Collectors;
 
 @Tag(name = "채널 API")
 @RestController
@@ -44,12 +34,9 @@ import java.util.stream.Collectors;
 public class ChannelApiController {
 
     private final ChannelService channelService;
+    private final ChannelRepository channelRepository;
     private final MemberService memberService;
-    private final FileService fileService;
-    private final FileStore fileStore;
 
-    @Value("${file.dir}")
-    private String fileDir;
 
     /**
      * 생성
@@ -59,47 +46,17 @@ public class ChannelApiController {
         return channelService.create(channelRequest);
     }
 
-    @PostMapping("/channel/descriptionFiles/base64")
-    public ResponseEntity storeDescriptionFilesByBase64(@RequestBody Base64Dto files) throws IOException {
-        System.out.println(files.getBase64());
-        System.out.println(files.getName());
-
-        File file = new File(fileDir + "/" + files.getName());
-        FileOutputStream fileOutputStream = new FileOutputStream(file);
-        Base64.Decoder decoder = Base64.getDecoder();
-
-        byte[] decodedBytes = decoder.decode(files.getBase64().getBytes());
-        fileOutputStream.write(decodedBytes);
-        fileOutputStream.close();
-
-        return new ResponseEntity(HttpStatus.OK);
-    }
-
-    @PostMapping("/channel/descriptionFiles")
-    public ResponseEntity storeDescriptionFilesByMultipart(MultipartFile files) throws IOException {
-        if (files == null || files.isEmpty()) {
-            throw new ImageNotFoundException("파일이 없습니다");
-        }
-
-        UploadFile uploadFiles = fileStore.storeFile(ImageType.CHANNEL, files);
-        ChannelFileResponse channelFileResponse = new ChannelFileResponse(uploadFiles.getStoreFileName(),
-                uploadFiles);
-
-        return new ResponseEntity(channelFileResponse, HttpStatus.OK);
+    @PostMapping("/channel/description/files/base64")
+    public ResponseEntity storeDescriptionFilesByBase64(@RequestBody Base64Dto base64) throws IOException {
+        channelService.createFileByBase64(base64);
+        return ResponseEntity.ok().body("파일 생성 완료");
     }
 
     @PostMapping("/channel/thumbnail")
-    public ResponseEntity storeChannelThumbnail(MultipartFile file) throws IOException {
-        UploadFile uploadFile;
+    public ResponseEntity createChannelThumbnail(MultipartFile file) throws IOException {
+        UploadFile thumbnail = channelService.createChannelThumbnail(file);
 
-        if (file == null || file.isEmpty()) {
-            uploadFile = new UploadFile("default.png", FileStore.CHANNEL_DEFAULT_THUMBNAIL_IMAGE);
-        }
-        else {
-            uploadFile = fileStore.storeFile(ImageType.CHANNEL_THUMBNAIL, file);
-        }
-
-        return new ResponseEntity(uploadFile, HttpStatus.OK);
+        return ResponseEntity.ok().body(thumbnail);
     }
 
     @PostMapping("/channel/{channelId}/waiting-member")
@@ -122,30 +79,20 @@ public class ChannelApiController {
      * 조회
      * */
     @GetMapping("/channels")
-    public Result channels() {
-        List<Channel> channels = channelService.findAll();
+    public Result getAll() {
+        List<ChannelResponse> channels = channelService.getAll();
 
-        List<ChannelResponse> responseList = channels.stream().map(c -> new ChannelResponse(c.getId(),
-                        c.getName(), c.getLimitedMemberNumber(), c.getManagerName(), c.getMember().getId(),
-                        c.getDescription(), c.getThumbnailDescription(), c.getMemberCount(),
-                        c.getThumbnailImage().getStoreFileName()))
-                .collect(Collectors.toList());
-
-        return new Result(responseList, responseList.size());
+        return new Result(channels, channels.size());
     }
 
     @GetMapping("/channel/{channelId}")
-    public ChannelResponse channel(@PathVariable Long channelId) {
-        Channel findChannel = channelService.findOne(channelId);
-
-        return new ChannelResponse(findChannel.getId(), findChannel.getName(), findChannel.getLimitedMemberNumber(),
-                findChannel.getManagerName(), findChannel.getMember().getId(), findChannel.getDescription(), findChannel.getThumbnailDescription(),
-                findChannel.getMemberCount(), findChannel.getThumbnailImage().getStoreFileName());
+    public ChannelResponse getByChannelId(@PathVariable Long channelId) {
+        return channelService.getById(channelId);
     }
 
     @GetMapping("/channel/{channelId}/description")
-    public ChannelDescriptionResponse channelDescription(@PathVariable Long channelId) {
-        Channel findChannel = channelService.findOne(channelId);
+    public ChannelDescriptionResponse getChannelDescriptionInfo(@PathVariable Long channelId) {
+        Channel findChannel = channelRepository.findById(channelId);
 
         return new ChannelDescriptionResponse(findChannel.getName(), findChannel.getDescription(), findChannel.getThumbnailDescription(),
                 DateTimeFormatter.ofPattern(DateFormat.DATE_FORMAT).format(findChannel.getDateCreated()),
@@ -154,72 +101,33 @@ public class ChannelApiController {
     }
 
     @GetMapping("/channels/{category}")
-    public Result findByCategory(@PathVariable ChannelCategory category) {
-        List<Channel> findChannels = channelService.findByCategory(category);
+    public Result getByCategory(@PathVariable ChannelCategory category) {
+        List<ChannelResponse> findChannels = channelService.getByCategory(category);
 
-        List<ChannelResponse> responseList = findChannels.stream().map(c -> new ChannelResponse(c.getId(),
-                        c.getName(), c.getLimitedMemberNumber(), c.getManagerName(), c.getMember().getId(),
-                        c.getDescription(), c.getThumbnailDescription(), c.getMemberCount(),
-                        c.getThumbnailImage().getStoreFileName()))
-                .collect(Collectors.toList());
-
-        return new Result(responseList, responseList.size());
+        return new Result(findChannels, findChannels.size());
     }
 
-    @GetMapping(path = "/channel/{id}/thumbnail", produces = "image/jpeg")
-    public Resource findMemberProfile(@PathVariable Long id) throws MalformedURLException {
-        Channel findChannel = channelService.findOne(id);
-
-        if (findChannel.getThumbnailImage() == null) {
-            throw new ImageNotFoundException("썸네일 사진을 찾을 수 없습니다");
-        }
-
-        UploadFile uploadFile = findChannel.getThumbnailImage();
-        String fullPath = fileStore.getFullPath(uploadFile.getStoreFileName());
-
-        /*
-         * @ResponseBody + byte[]또는, Resource를 반환하는 경우 바이트 정보가 반환됩니다.
-         * <img> 에서는 이 바이트 정보를 읽어서 이미지로 반환하게 됩니다.
-         *
-         * Resource를 리턴할 때 ResourceHttpMessageConverter가 해당 리소스의 바이트 정보를 응답 바디에 담아줍니다.
-         * */
-        return new UrlResource("file:" + fullPath);
+    @GetMapping(path = "/channel/{channelId}/thumbnail", produces = "image/jpeg")
+    public Resource findMemberProfile(@PathVariable Long channelId) throws MalformedURLException {
+        return channelService.getThumbNailImage(channelId);
     }
 
     @GetMapping("/channel/{channelId}/members")
     public Result channelMembers(@PathVariable Long channelId,
                                  @RequestParam(required = false) Long page,
                                  @RequestParam(required = false) Long count) {
-        List<Member> members = memberService.findByChannelId(channelId, page, 5L);
+        List<MemberResponse> members = memberService.findByChannelId(channelId, page, 5L);
 
-        List<MemberResponse> memberResponses = members.stream()
-                .map(m -> new MemberResponse(m.getEmail(), m.getName(), m.getGender(), m.getBirthday(),
-                        m.getPhone(), m.getUploadFile()))
-                .collect(Collectors.toList());
-
-        return new Result(memberResponses, memberResponses.size());
+        return new Result(members, members.size());
     }
 
     @GetMapping("/channel/{channelId}/waiting-members")
     public Result channelWaitingMembers(@PathVariable Long channelId,
                                         @RequestParam(required = false) Long page,
                                         @RequestParam(required = false) Long count) {
-        List<Member> waitingMembers = memberService.findWaitingMemberByChannelId(channelId, page);
+        List<MemberResponse> waitingMembers = memberService.findWaitingMemberByChannelId(channelId, page);
 
-        List<MemberResponse> memberResponses = waitingMembers.stream()
-                .map(m -> new MemberResponse(m.getEmail(), m.getName(), m.getGender(), m.getBirthday(),
-                        m.getPhone(), m.getUploadFile()))
-                .collect(Collectors.toList());
-
-        return new Result(memberResponses, memberResponses.size());
-    }
-
-    @Data
-    @AllArgsConstructor
-    public static class ManagerPostResponse{
-        private Long id;
-        private String title;
-        private String writer;
+        return new Result(waitingMembers, waitingMembers.size());
     }
 
 
@@ -227,16 +135,21 @@ public class ChannelApiController {
      * 수정
      * */
     @PatchMapping("/channel/{channelId}")
-    public ResponseEntity updateDetailDescription(@PathVariable Long channelId,
+    public ResponseEntity modifyDetailDescription(@PathVariable Long channelId,
                                                   @RequestBody @Validated UpdateChannelRequest channelRequest) {
         channelService.update(channelId, channelRequest.getName(), channelRequest.getLimitedMemberNumber(),
                 channelRequest.getDescription(), channelRequest.getThumbnailDescription(), channelRequest.getThumbnailImage());
 
-        Channel findChannel = channelService.findOne(channelId);
-        return new ResponseEntity(new UpdateChannelResponse(findChannel.getName(),
-                findChannel.getLimitedMemberNumber(), findChannel.getDescription(),
-                findChannel.getThumbnailDescription(), findChannel.getThumbnailImage()),
-                HttpStatus.OK);
+        ChannelResponse findChannel = channelService.getById(channelId);
+        return ResponseEntity.ok().body(findChannel);
+    }
+
+    @PatchMapping("/channel/{channelId}/thumbnail")
+    public ResponseEntity modifyChannelThumbnail(@PathVariable Long channelId,
+                                                 MultipartFile file) throws IOException {
+        UploadFile thumbNail = channelService.modifyChannelThumbNail(file, channelId);
+
+        return ResponseEntity.ok().body(thumbNail);
     }
 
 

--- a/backend/api/src/main/java/com/levelup/api/api/ChannelManagerApiController.java
+++ b/backend/api/src/main/java/com/levelup/api/api/ChannelManagerApiController.java
@@ -11,7 +11,7 @@ import com.levelup.core.dto.channel.ManagerPostResponse;
 import com.levelup.core.dto.channel.ManagerResponse;
 import com.levelup.core.dto.member.MemberResponse;
 import com.levelup.core.dto.post.PostSearch;
-import com.levelup.core.exception.NotLoggedInException;
+import com.levelup.core.repository.channel.ChannelRepository;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -32,6 +32,7 @@ import java.util.stream.Collectors;
 public class ChannelManagerApiController {
 
     private final ChannelService channelService;
+    private final ChannelRepository channelRepository;
     private final PostService postService;
     private final MemberService memberService;
 
@@ -43,7 +44,7 @@ public class ChannelManagerApiController {
     @GetMapping("/channel/{channelId}/manager")
     public ManagerResponse channel(@PathVariable Long channelId,
                                    @AuthenticationPrincipal Long id) {
-        Channel channel = channelService.findOne(channelId);
+        Channel channel = channelRepository.findById(channelId);
         Member findMember = memberService.findOne(id);
         List<Member> waitingMembers = memberService.findWaitingMemberByChannelId(channelId);
         List<Member> members = memberService.findByChannelId(channelId);

--- a/backend/api/src/main/java/com/levelup/api/api/ChannelNoticeApiController.java
+++ b/backend/api/src/main/java/com/levelup/api/api/ChannelNoticeApiController.java
@@ -3,6 +3,7 @@ package com.levelup.api.api;
 import com.levelup.api.service.ChannelNoticeService;
 import com.levelup.api.service.ChannelService;
 import com.levelup.api.service.FileService;
+import com.levelup.api.service.MemberService;
 import com.levelup.core.domain.file.FileStore;
 import com.levelup.core.domain.file.ImageType;
 import com.levelup.core.domain.file.UploadFile;
@@ -35,8 +36,10 @@ public class ChannelNoticeApiController {
 
     private final ChannelNoticeService channelNoticeService;
     private final ChannelService channelService;
+    private final MemberService memberService;
     private final FileStore fileStore;
     private final FileService fileService;
+
 
     /**
      * 생성
@@ -45,10 +48,11 @@ public class ChannelNoticeApiController {
     public ResponseEntity create(@RequestParam Long channel,
                                  @RequestBody @Validated ChannelNoticeRequest noticeRequest,
                                  @AuthenticationPrincipal Long memberId) {
-        Member manager = channelService.findOne(channel).getMember();
+        Long managerId = channelService.getById(channel).getManagerId();
+        Member member = memberService.findOne(memberId);
 
-        if (Long.valueOf(memberId).equals(manager.getId())) {
-            Long id = channelNoticeService.create(channel, noticeRequest.getTitle(), manager.getName(),
+        if (memberId.equals(managerId)) {
+            Long id = channelNoticeService.create(channel, noticeRequest.getTitle(), member.getName(),
                     noticeRequest.getContent());
 
             ChannelNotice channelNotice = channelNoticeService.findById(id);
@@ -139,9 +143,9 @@ public class ChannelNoticeApiController {
                                  @RequestParam Long channel,
                                  @RequestBody @Validated ChannelNoticeRequest noticeRequest,
                                  @AuthenticationPrincipal Long memberId) {
-        Member manager = channelService.findOne(channel).getMember();
+        Long managerId = channelService.getById(channel).getManagerId();
 
-        if (memberId.equals(manager.getId())) {
+        if (memberId.equals(managerId)) {
             channelNoticeService.upadte(id, noticeRequest.getTitle(), noticeRequest.getContent());
             return new ResponseEntity(new Result("채널 공지사항이 수정되었습니다.", 0), HttpStatus.CREATED);
         }
@@ -157,9 +161,9 @@ public class ChannelNoticeApiController {
     public ResponseEntity deleteAll(@RequestParam Long channel,
                                  @RequestBody @Validated DeleteChannelNoticeRequest noticeRequest,
                                  @AuthenticationPrincipal Long memberId) {
-        Member manager = channelService.findOne(channel).getMember();
+        Long managerId = channelService.getById(channel).getManagerId();
 
-        if (Long.valueOf(memberId).equals(manager.getId())) {
+        if (memberId.equals(managerId)) {
             channelNoticeService.deleteAll(noticeRequest.getIds());
             return new ResponseEntity(new Result("삭제되었습니다", 0), HttpStatus.OK);
         }
@@ -171,9 +175,9 @@ public class ChannelNoticeApiController {
     public ResponseEntity delet0e(@PathVariable Long channelNoticeId,
                                  @RequestParam Long channel,
                                  @AuthenticationPrincipal Long memberId) {
-        Member manager = channelService.findOne(channel).getMember();
+        Long managerId = channelService.getById(channel).getManagerId();
 
-        if (memberId.equals(manager.getId())) {
+        if (memberId.equals(managerId)) {
             channelNoticeService.delete(channelNoticeId);
             return new ResponseEntity(new Result("삭제되었습니다", 0), HttpStatus.OK);
         }

--- a/backend/api/src/main/java/com/levelup/api/service/ChannelService.java
+++ b/backend/api/src/main/java/com/levelup/api/service/ChannelService.java
@@ -4,19 +4,33 @@ package com.levelup.api.service;
 import com.levelup.core.domain.channel.Channel;
 import com.levelup.core.domain.channel.ChannelCategory;
 import com.levelup.core.domain.channel.ChannelMember;
+import com.levelup.core.domain.file.Base64Dto;
+import com.levelup.core.domain.file.FileStore;
+import com.levelup.core.domain.file.ImageType;
 import com.levelup.core.domain.file.UploadFile;
 import com.levelup.core.domain.member.Member;
 import com.levelup.core.dto.channel.ChannelRequest;
+import com.levelup.core.dto.channel.ChannelResponse;
 import com.levelup.core.dto.channel.CreateChannelResponse;
+import com.levelup.core.exception.ImageNotFoundException;
 import com.levelup.core.repository.channel.ChannelMemberRepository;
 import com.levelup.core.repository.channel.ChannelRepository;
 import com.levelup.core.repository.member.MemberRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.UrlResource;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.net.MalformedURLException;
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -26,10 +40,14 @@ public class ChannelService {
     private final ChannelRepository channelRepository;
     private final ChannelMemberRepository channelMemberRepository;
     private final MemberRepository memberRepository;
+    private final FileStore fileStore;
 //    private final ChannelMemberRepository channelMemberRepository;
 
+    @Value("${file.dir}")
+    private String fileDir;
+
     /**
-     * 채널 추가
+     * 생성
      * */
     public CreateChannelResponse create(ChannelRequest channelRequest) {
         validationDuplicateChannel(channelRequest.getName());
@@ -54,9 +72,6 @@ public class ChannelService {
         }
     }
 
-    /**
-     * 채널에 멤버 추가
-     * */
     public void addMember(Long channelId, List<Long> memberIds) {
         Channel channel = channelRepository.findById(channelId);
         List<ChannelMember> channelMembers = new ArrayList<>();
@@ -99,18 +114,56 @@ public class ChannelService {
         channel.addWaitingMember(channelMembers);
     }
 
+    public void createFileByBase64(Base64Dto base64) throws IOException {
+        File file = new File(fileDir + "/" + base64.getName()); //파일 생성 경로 수정해야됨
+        FileOutputStream fileOutputStream = new FileOutputStream(file);
+
+        Base64.Decoder decoder = Base64.getDecoder();
+
+        byte[] decodedBytes = decoder.decode(base64.getBase64().getBytes());
+        fileOutputStream.write(decodedBytes);
+
+        fileOutputStream.close();
+    }
+
+    public UploadFile createChannelThumbnail(MultipartFile file) throws IOException {
+        return fileStore.storeFile(ImageType.CHANNEL_THUMBNAIL, file);
+    }
+
+
     /**
      * 채널 수정
      * */
     public void update(Long channelId, String name, Long limitNumber, String description, String thumbnailDescription, UploadFile thumbnailImage) {
         Channel channel = channelRepository.findById(channelId);
-        channel.changeChannel(name, limitNumber, description, thumbnailDescription, thumbnailImage);
+        channel.modifyChannel(name, limitNumber, description, thumbnailDescription, thumbnailImage);
     }
 
     public void update(Long channelId, String name, Long limitNumber, String description, String thumbnailDescription, ChannelCategory category, UploadFile thumbnailImage) {
         Channel channel = channelRepository.findById(channelId);
-        channel.changeChannel(name, limitNumber, description, thumbnailDescription, category, thumbnailImage);
+        channel.modifyChannel(name, limitNumber, description, thumbnailDescription, category, thumbnailImage);
     }
+
+    public UploadFile modifyChannelThumbNail(MultipartFile file, Long channelId) throws IOException {
+        Channel channel = channelRepository.findById(channelId);
+
+        deleteChannelThumbNail(channel.getThumbnailImage().getStoreFileName());
+
+        UploadFile thumbNail = fileStore.storeFile(ImageType.MEMBER, file);
+        channel.modifyThumbNail(thumbNail);
+        return thumbNail;
+    }
+
+    private void deleteChannelThumbNail(String storeFileName) {
+        if (!storeFileName.equals(FileStore.MEMBER_DEFAULT_IMAGE)) {
+            File imageFile = new File(fileStore.getFullPath(storeFileName));
+            if (imageFile.exists()) {
+                imageFile.delete();
+            }
+        }
+    }
+
+
 
     /**
      * 채널 삭제
@@ -132,7 +185,7 @@ public class ChannelService {
     }
 
     public void deleteMember(Long channelId, String email) {
-        Channel findChannel = findOne(channelId);
+        Channel findChannel = channelRepository.findById(channelId);
         Member findMember = memberRepository.findByEmail(email);
 
         List<ChannelMember> members = channelMemberRepository.findByChannelAndMember(channelId, findMember.getId());
@@ -144,7 +197,7 @@ public class ChannelService {
     }
 
     public void deleteWaitingMember(Long channelId, String email) {
-        Channel findChannel = findOne(channelId);
+        Channel findChannel = channelRepository.findById(channelId);
         Member findMember = memberRepository.findByEmail(email);
 
         List<ChannelMember> waitingMember = channelMemberRepository
@@ -161,24 +214,57 @@ public class ChannelService {
     /**
      * 채널 조회
      * */
-    public Channel findOne(Long channelId) {
-        return channelRepository.findById(channelId);
+    public ChannelResponse getById(Long channelId) {
+        Channel findChannel = channelRepository.findById(channelId);
+
+        return new ChannelResponse(findChannel.getId(), findChannel.getName(), findChannel.getLimitedMemberNumber(),
+                findChannel.getManagerName(), findChannel.getMember().getId(), findChannel.getDescription(), findChannel.getThumbnailDescription(),
+                findChannel.getMemberCount(), findChannel.getThumbnailImage().getStoreFileName());
     }
 
-    public List<Channel> findAll() {
-        return channelRepository.findAll();
-    }
-
-    public List<Channel> findAll(int start, int end) {
-        return channelRepository.findAll(start, end);
-    }
-
-    public List<Channel> findByMemberId(Long memberId) {
+    public List<Channel> getByMemberId(Long memberId) {
         return channelRepository.findByMemberId(memberId);
     }
 
-    public List<Channel> findByCategory(ChannelCategory category) {
-        return channelRepository.findByCategory(category);
+    public List<ChannelResponse> getByCategory(ChannelCategory category) {
+        return channelRepository.findByCategory(category)
+                .stream().map(c -> new ChannelResponse(c.getId(),
+                        c.getName(), c.getLimitedMemberNumber(), c.getManagerName(), c.getMember().getId(),
+                        c.getDescription(), c.getThumbnailDescription(), c.getMemberCount(),
+                        c.getThumbnailImage().getStoreFileName()))
+                .collect(Collectors.toList());
+    }
+
+    public List<ChannelResponse> getAll() {
+        return channelRepository.findAll().stream()
+                .map(c -> new ChannelResponse(c.getId(),
+                        c.getName(), c.getLimitedMemberNumber(), c.getManagerName(), c.getMember().getId(),
+                        c.getDescription(), c.getThumbnailDescription(), c.getMemberCount(),
+                        c.getThumbnailImage().getStoreFileName()))
+                .collect(Collectors.toList());
+    }
+
+    public List<Channel> getAll(int start, int end) {
+        return channelRepository.findAll(start, end);
+    }
+
+    public UrlResource getThumbNailImage(Long channelId) throws MalformedURLException {
+        Channel findChannel = channelRepository.findById(channelId);
+
+        if (findChannel.getThumbnailImage() == null) {
+            throw new ImageNotFoundException("썸네일 사진을 찾을 수 없습니다");
+        }
+
+        UploadFile uploadFile = findChannel.getThumbnailImage();
+        String fullPath = fileStore.getFullPath(uploadFile.getStoreFileName());
+
+        /*
+         * @ResponseBody + byte[]또는, Resource를 반환하는 경우 바이트 정보가 반환됩니다.
+         * <img> 에서는 이 바이트 정보를 읽어서 이미지로 반환하게 됩니다.
+         *
+         * Resource를 리턴할 때 ResourceHttpMessageConverter가 해당 리소스의 바이트 정보를 응답 바디에 담아줍니다.
+         * */
+        return new UrlResource("file:" + fullPath);
     }
 
 }

--- a/backend/api/src/main/java/com/levelup/api/service/MemberService.java
+++ b/backend/api/src/main/java/com/levelup/api/service/MemberService.java
@@ -14,7 +14,6 @@ import com.levelup.core.exception.MemberNotFoundException;
 import com.levelup.core.repository.member.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.core.io.Resource;
 import org.springframework.core.io.UrlResource;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -37,9 +36,6 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 @Transactional
 public class MemberService implements UserDetailsService {
-
-    final int HANGUL_UNICODE_START = 0xAC00;
-    final int HANGUL_UNICODE_END = 0xD7AF;
 
     private final PasswordEncoder passwordEncoder;
     private final MemberRepository memberRepository;

--- a/backend/api/src/main/java/com/levelup/api/service/MemberService.java
+++ b/backend/api/src/main/java/com/levelup/api/service/MemberService.java
@@ -71,10 +71,6 @@ public class MemberService implements UserDetailsService {
          * 먼저 이 api로 이미지를 저장한 후 이미지의 경로명을 클라이언트에게 리턴(ResponseEntity(uploadFile, HttpStatus.OK))
          * 그러면 클라이언트는 받은 경로를 객체에 저장한 후 회원가입 api를 호출함
          * */
-        if (file == null || file.isEmpty()) {
-            throw new ImageNotFoundException("존재하지 않는 이미지입니다.");
-        }
-
         return fileStore.storeFile(ImageType.MEMBER, file);
     }
 
@@ -112,16 +108,24 @@ public class MemberService implements UserDetailsService {
         return memberRepository.findByChannelId(channelId);
     }
 
-    public List<Member> findByChannelId(Long channelId, Long page, Long count) {
-        return memberRepository.findByChannelId(channelId, Math.toIntExact(page), Math.toIntExact(count));
+    public List<MemberResponse> findByChannelId(Long channelId, Long page, Long count) {
+        return memberRepository.findByChannelId(channelId, Math.toIntExact(page), Math.toIntExact(count))
+                .stream()
+                .map(m -> new MemberResponse(m.getEmail(), m.getName(), m.getGender(), m.getBirthday(),
+                        m.getPhone(), m.getUploadFile()))
+                .collect(Collectors.toList());
     }
 
     public List<Member> findWaitingMemberByChannelId(Long channelId) {
         return memberRepository.findWaitingMemberByChannelId(channelId);
     }
 
-    public List<Member> findWaitingMemberByChannelId(Long channelId, Long page) {
-        return memberRepository.findWaitingMemberByChannelId(channelId, Math.toIntExact(page), 5);
+    public List<MemberResponse> findWaitingMemberByChannelId(Long channelId, Long page) {
+        return memberRepository.findWaitingMemberByChannelId(channelId, Math.toIntExact(page), 5)
+                .stream()
+                .map(m -> new MemberResponse(m.getEmail(), m.getName(), m.getGender(), m.getBirthday(),
+                        m.getPhone(), m.getUploadFile()))
+                .collect(Collectors.toList());
     }
 
     public UrlResource getProfileImage(String email) throws MalformedURLException {

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -46,6 +46,10 @@ subprojects {
         annotationProcessor 'org.projectlombok:lombok'
 
         testImplementation 'org.springframework.boot:spring-boot-starter-test'
+        //JUnit4 추가
+        testImplementation("org.junit.vintage:junit-vintage-engine") {
+            exclude group: "org.hamcrest", module: "hamcrest-core"
+        }
     }
 
     test {

--- a/backend/core/src/main/java/com/levelup/core/CoreApplication.java
+++ b/backend/core/src/main/java/com/levelup/core/CoreApplication.java
@@ -1,0 +1,13 @@
+package com.levelup.core;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class CoreApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(CoreApplication.class, args);
+    }
+
+}

--- a/backend/core/src/main/java/com/levelup/core/domain/channel/Channel.java
+++ b/backend/core/src/main/java/com/levelup/core/domain/channel/Channel.java
@@ -197,7 +197,7 @@ public class Channel {
         }
     }
 
-    public void changeChannel(String name, Long limitNumber, String description, String thumbnailDescription, UploadFile thumbnailImage) {
+    public void modifyChannel(String name, Long limitNumber, String description, String thumbnailDescription, UploadFile thumbnailImage) {
         this.name = name;
         this.limitedMemberNumber = limitNumber;
         this.description = description;
@@ -205,13 +205,17 @@ public class Channel {
         this.thumbnailImage = thumbnailImage;
     }
 
-    public void changeChannel(String name, Long limitNumber, String description, String thumbnailDescription, ChannelCategory category, UploadFile thumbnailImage) {
+    public void modifyChannel(String name, Long limitNumber, String description, String thumbnailDescription, ChannelCategory category, UploadFile thumbnailImage) {
         this.name = name;
         this.limitedMemberNumber = limitNumber;
         this.description = description;
         this.thumbnailDescription = thumbnailDescription;
         this.thumbnailImage = thumbnailImage;
         this.category = category;
+    }
+
+    public void modifyThumbNail(UploadFile thumbnailImage) {
+        this.thumbnailImage = thumbnailImage;
     }
 
 }

--- a/backend/core/src/main/java/com/levelup/core/domain/channel/Channel.java
+++ b/backend/core/src/main/java/com/levelup/core/domain/channel/Channel.java
@@ -6,10 +6,7 @@ import com.levelup.core.domain.member.Member;
 import com.levelup.core.domain.notice.ChannelNotice;
 import com.levelup.core.domain.post.Post;
 import com.levelup.core.exception.NoPlaceChnnelException;
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
 
 import javax.persistence.*;
 import java.time.LocalDateTime;
@@ -18,7 +15,9 @@ import java.util.List;
 
 @Entity
 @Table(name = "channel")
-@Getter @Setter
+@Getter
+@Builder
+@AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Channel {
 
@@ -92,26 +91,6 @@ public class Channel {
     public void setChannelMember(ChannelMember channelMember) {
         this.channelMembers.add(channelMember);
         channelMember.setChannel(this);
-    }
-
-    //==생성 메서드==//
-    public static Channel createChannel(Member member, String name, Long limitNumber, String description, String thumbnailDescription, ChannelCategory category, UploadFile thumbnailImage) {
-        Channel channel = new Channel();
-
-        channel.setMember(member);
-        channel.setName(name);
-//        channel.setManagerName(member.getName());
-        channel.setManagerName(member.getEmail());
-        channel.setLimitedMemberNumber(limitNumber);
-        channel.setDescription(description);
-        channel.setThumbnailDescription(thumbnailDescription);
-        channel.setDateCreated(LocalDateTime.now());
-        channel.setMemberCount(0L);
-        channel.setWaitingMemberCount(0L);
-        channel.setCategory(category);
-        channel.setThumbnailImage(thumbnailImage);
-
-        return channel;
     }
 
     //==비즈니스 로직==//
@@ -219,20 +198,20 @@ public class Channel {
     }
 
     public void changeChannel(String name, Long limitNumber, String description, String thumbnailDescription, UploadFile thumbnailImage) {
-        this.setName(name);
-        this.setLimitedMemberNumber(limitNumber);
-        this.setDescription(description);
-        this.setThumbnailDescription(thumbnailDescription);
-        this.setThumbnailImage(thumbnailImage);
+        this.name = name;
+        this.limitedMemberNumber = limitNumber;
+        this.description = description;
+        this.thumbnailDescription = thumbnailDescription;
+        this.thumbnailImage = thumbnailImage;
     }
 
     public void changeChannel(String name, Long limitNumber, String description, String thumbnailDescription, ChannelCategory category, UploadFile thumbnailImage) {
-        this.setName(name);
-        this.setLimitedMemberNumber(limitNumber);
-        this.setDescription(description);
-        this.setThumbnailDescription(thumbnailDescription);
-        this.setThumbnailImage(thumbnailImage);
-        this.setCategory(category);
+        this.name = name;
+        this.limitedMemberNumber = limitNumber;
+        this.description = description;
+        this.thumbnailDescription = thumbnailDescription;
+        this.thumbnailImage = thumbnailImage;
+        this.category = category;
     }
 
 }

--- a/backend/core/src/main/java/com/levelup/core/dto/channel/ChannelRequest.java
+++ b/backend/core/src/main/java/com/levelup/core/dto/channel/ChannelRequest.java
@@ -1,14 +1,21 @@
 package com.levelup.core.dto.channel;
 
+import com.levelup.core.domain.channel.Channel;
 import com.levelup.core.domain.channel.ChannelCategory;
 import com.levelup.core.domain.file.UploadFile;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
-import javax.persistence.EmbeddedId;
 import javax.validation.constraints.NotNull;
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
 public class ChannelRequest {
 
     @NotNull
@@ -33,5 +40,20 @@ public class ChannelRequest {
     private UploadFile thumbnailImage;
 
     private List<UploadFile> uploadFiles;
+
+    public Channel toEntity() {
+        return Channel.builder()
+                .name(name)
+                .managerName(memberEmail)
+                .limitedMemberNumber(limitedMemberNumber)
+                .description(description)
+                .thumbnailDescription(thumbnailDescription)
+                .dateCreated(LocalDateTime.now())
+                .memberCount(0L)
+                .waitingMemberCount(0L)
+                .category(category)
+                .thumbnailImage(thumbnailImage)
+                .build();
+    }
 
 }

--- a/backend/core/src/main/java/com/levelup/core/dto/channel/ChannelResponse.java
+++ b/backend/core/src/main/java/com/levelup/core/dto/channel/ChannelResponse.java
@@ -18,4 +18,5 @@ public class ChannelResponse {
     private Long memberCount;
     private String storeFileName;
 
+
 }

--- a/backend/core/src/main/java/com/levelup/core/repository/member/JpaMemberRepository.java
+++ b/backend/core/src/main/java/com/levelup/core/repository/member/JpaMemberRepository.java
@@ -17,8 +17,10 @@ public class JpaMemberRepository implements MemberRepository {
      * 생성
      * */
     @Override
-    public void save(Member member) {
+    public Long save(Member member) {
         em.persist(member);
+
+        return member.getId();
     }
 
 

--- a/backend/core/src/main/java/com/levelup/core/repository/member/MemberRepository.java
+++ b/backend/core/src/main/java/com/levelup/core/repository/member/MemberRepository.java
@@ -7,7 +7,7 @@ import java.util.List;
 
 public interface MemberRepository {
 
-    void save(Member member);
+    Long save(Member member);
     Member findById(Long id);
     Member findByEmail(String email);
     Member findByEmailAndPassword(String email, String password);

--- a/backend/core/src/test/java/domain/member/MemberRepositoryTest.java
+++ b/backend/core/src/test/java/domain/member/MemberRepositoryTest.java
@@ -1,0 +1,41 @@
+package domain.member;
+
+import com.levelup.core.CoreApplication;
+import com.levelup.core.domain.member.Authority;
+import com.levelup.core.domain.member.Gender;
+import com.levelup.core.domain.member.Member;
+import com.levelup.core.repository.member.MemberRepository;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+@Transactional
+@SpringBootTest(classes = CoreApplication.class)
+class MemberRepositoryTest {
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Test
+    public void 멤버_생성() {
+        Member member = new Member();
+        member.setEmail("test1@test.com");
+        member.setPassword("00000000");
+        member.setName("test");
+        member.setGender(Gender.MALE);
+        member.setBirthday("970927");
+        member.setPhone("010-4646-4654");
+        member.setUploadFile(null);
+        member.setDateCreated(LocalDateTime.now());
+        member.setAuthority(Authority.NORMAL);
+
+        Long memberId = memberRepository.save(member);
+        Member findMember = memberRepository.findById(memberId);
+        Assertions.assertThat(memberId).isEqualTo(findMember.getId());
+    }
+
+}

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -24,8 +24,8 @@
     <script src="https://stackpath.bootstrapcdn.com/bootstrap/3.4.1/js/bootstrap.min.js"></script>
 
 <!--&lt;!&ndash;     include summernote css/js&ndash;&gt;-->
-    <link href="https://cdn.jsdelivr.net/npm/summernote@0.8.18/dist/summernote.min.css" rel="stylesheet">
-    <script src="https://cdn.jsdelivr.net/npm/summernote@0.8.18/dist/summernote.min.js"></script>
+<!--    <link href="https://cdn.jsdelivr.net/npm/summernote@0.8.18/dist/summernote.min.css" rel="stylesheet">-->
+<!--    <script src="https://cdn.jsdelivr.net/npm/summernote@0.8.18/dist/summernote.min.js"></script>-->
 
     <!--
       Notice the use of %PUBLIC_URL% in the tags above.
@@ -42,67 +42,67 @@
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <div id="root"></div>
 
-    <script type="module">
-      function uploadImage(files, editor) {
-        let form = new FormData();
-        form.append("files", files);
+<!--    <script type="module">-->
+<!--      function uploadImage(files, editor) {-->
+<!--        let form = new FormData();-->
+<!--        form.append("files", files);-->
 
-        const TOKEN = 'ACCESS_TOKEN'
-        const BACKEND_URL = "http://localhost:8080"
+<!--        const TOKEN = 'ACCESS_TOKEN'-->
+<!--        const BACKEND_URL = "http://localhost:8080"-->
 
-        let headers = {
-        }
+<!--        let headers = {-->
+<!--        }-->
 
-        const accessToken = sessionStorage.getItem(TOKEN)
-        if (accessToken && accessToken !== null) {
-          headers.Authorization = "Bearer "+ accessToken
-        }
+<!--        const accessToken = sessionStorage.getItem(TOKEN)-->
+<!--        if (accessToken && accessToken !== null) {-->
+<!--          headers.Authorization = "Bearer "+ accessToken-->
+<!--        }-->
 
-        let options = {
-          url: BACKEND_URL + '/api/channel/descriptionFiles',
-          method: 'POST',
-          headers : headers,
-          data: form,
-          async: false,
-          processData: false, // - processData : false로 선언 시 formData를 string으로 변환하지 않음
-          contentType: false, // - contentType : false 로 선언 시 content-type 헤더가 multipart/form-data로 전송되게 함
-          cache: false,
-          enctype: 'multipart/form-data',
-        }
+<!--        let options = {-->
+<!--          url: BACKEND_URL + '/api/channel/descriptionFiles',-->
+<!--          method: 'POST',-->
+<!--          headers : headers,-->
+<!--          data: form,-->
+<!--          async: false,-->
+<!--          processData: false, // - processData : false로 선언 시 formData를 string으로 변환하지 않음-->
+<!--          contentType: false, // - contentType : false 로 선언 시 content-type 헤더가 multipart/form-data로 전송되게 함-->
+<!--          cache: false,-->
+<!--          enctype: 'multipart/form-data',-->
+<!--        }-->
 
-        $.ajax(options)
-            .done(function (response) {
-              console.log(response)
-              $(editor).summernote('insertImage', BACKEND_URL + response.fullPath)
-            })
-            .fail(function (error) {
-              console.log(error)
-            })
-      }
+<!--        $.ajax(options)-->
+<!--            .done(function (response) {-->
+<!--              console.log(response)-->
+<!--              $(editor).summernote('insertImage', BACKEND_URL + response.fullPath)-->
+<!--            })-->
+<!--            .fail(function (error) {-->
+<!--              console.log(error)-->
+<!--            })-->
+<!--      }-->
 
-      $(document).ready(function() {
-        $('#summernote').summernote({
-          height: 400,
-          minHeight: null,
-          maxHeight: null,
-          callbacks: {
-            onImageUpload : function(files) {
-              for (let i = 0; i < files.length; i++) {
-                uploadImage(files[i], this);
-              }
-            },
-            onPaste: function (e) {
-              let clipboardData = e.originalEvent.clipboardData;
-              if (clipboardData && clipboardData.items && clipboardData.items.length) {
-                let item = clipboardData.items[0];
-                if (item.kind === 'file' && item.type.indexOf('image/') !== -1) {
-                  e.preventDefault();
-                }
-              }
-            }
-          }
-        })
-      })
-    </script>
+<!--      $(document).ready(function() {-->
+<!--        $('#summernote').summernote({-->
+<!--          height: 400,-->
+<!--          minHeight: null,-->
+<!--          maxHeight: null,-->
+<!--          callbacks: {-->
+<!--            onImageUpload : function(files) {-->
+<!--              for (let i = 0; i < files.length; i++) {-->
+<!--                uploadImage(files[i], this);-->
+<!--              }-->
+<!--            },-->
+<!--            onPaste: function (e) {-->
+<!--              let clipboardData = e.originalEvent.clipboardData;-->
+<!--              if (clipboardData && clipboardData.items && clipboardData.items.length) {-->
+<!--                let item = clipboardData.items[0];-->
+<!--                if (item.kind === 'file' && item.type.indexOf('image/') !== -1) {-->
+<!--                  e.preventDefault();-->
+<!--                }-->
+<!--              }-->
+<!--            }-->
+<!--          }-->
+<!--        })-->
+<!--      })-->
+<!--    </script>-->
   </body>
 </html>

--- a/frontend/src/page/channel/ModifyChannel.js
+++ b/frontend/src/page/channel/ModifyChannel.js
@@ -27,14 +27,11 @@ const CreateChannel = () => {
     }
 
     const handleModifyButton = async () => {
-        let formData = new FormData(document.getElementById('form'));
         let thumbnailImageDir = description.thumbnailImage
 
         if (thumbnail !== null) {
-            thumbnailImageDir = await uploadFile('/api/member/image', 'POST', thumbnail)
+            thumbnailImageDir = await uploadFile('/api/channel/' + channelId + '/thumbnail', 'PATCH', thumbnail)
         }
-
-        // let uploadFiles = getUploadFiles(contents);
 
         let channel = {
             name : $('#name').val(),
@@ -43,7 +40,6 @@ const CreateChannel = () => {
             category : $('#category').val(),
             thumbnailDescription : $('#thumbnailDescription').val(),
             thumbnailImage : thumbnailImageDir,
-            // uploadFiles : uploadFiles,
         }
         console.log(channel)
 


### PR DESCRIPTION
기존 컨트롤러 계층에 있던 로직을 서비스 계층으로 옮김